### PR TITLE
Fix flow-flowstream not being root-aware

### DIFF
--- a/flow-flowstream.js
+++ b/flow-flowstream.js
@@ -627,7 +627,7 @@ Instance.prototype.reload = function(data) {
 				flow.$schema.unixsocket = data.unixsocket;
 			}
 
-			PROXIES[data.id] = F.proxy(data.proxypath, data.unixsocket);
+			PROXIES[data.id] = F.proxy((CONF.$root + meta.proxypath).replace(/\/{2,}/g, '/'), data.unixsocket);
 		}
 
 		for (let key in data)
@@ -1491,7 +1491,7 @@ function init_worker(meta, type, callback) {
 	}
 
 	if (meta.proxypath)
-		PROXIES[meta.id] = F.proxy(meta.proxypath, meta.unixsocket);
+		PROXIES[meta.id] = F.proxy((CONF.$root + meta.proxypath).replace(/\/{2,}/g, '/'), meta.unixsocket);
 
 	if (!worker.postMessage) {
 		worker.postMessage = worker.send;


### PR DESCRIPTION
Hi,

during further testing we noticed that proxies configured for incoming HTTP requests are still not root-aware. A workaround for this is to prefix `flow.proxypath` with the content of `$root`, for example `/flow/users/example` for `$root : /flow/`. However, the Route component will then display `https://domain.tld/flow/flow/users/example` as its relative URL. That's one `/flow` too much.

This PR is an attempt to fix this. Feel free to commit or request any required changes. 🙂

One quick question: When is `init_current` called in `flow-flowstream.js`? I haven't figured this out yet.