### PR TITLE
fix: reject odd-length hex strings in F.decrypt

### DIFF
--- a/index.js
+++ b/index.js
@@ -2662,6 +2662,9 @@ F.decrypt = function(value, key, tojson = true) {
 		if (!F.temporary.cryptokeys[key])
 			F.temporary.cryptokeys[key] = Buffer.from(key);
 
+		if (value && value.length % 2 !== 0)
+			return null;
+
 		var decipher = F.Crypto.createDecipheriv(F.config.$crypto, F.temporary.cryptokeys[key], F.config.$cryptoiv);
 		try {
 			CONCAT[0] = decipher.update(Buffer.from(value || '', 'hex'));


### PR DESCRIPTION
## Summary

Follow-up to #29, addressing the maintainer's feedback.

- Removes the arbitrary 65536-character size cap and the hex-character regex (both objected to in #29).
- Adds only the one check `petersirka` identified as legitimate: **reject odd-length hex strings** before passing them to `Buffer.from(value, 'hex')`.

`Buffer.from(value, 'hex')` silently truncates input whose character length is odd (it reads pairs of hex digits, so a trailing lone digit is dropped). Without this guard, decryption silently proceeds on a truncated — and therefore almost certainly invalid — byte sequence rather than returning `null`.

## Change

```js
if (value && value.length % 2 !== 0)
    return null;
```

Placed after the key-cache block and before `createDecipheriv`, so no decipher object is allocated for input that is already known-bad.

## Test plan

- [ ] `F.decrypt(F.encrypt(obj, key), key)` round-trips correctly (no size restriction)
- [ ] `F.decrypt('abc', key)` returns `null` (odd-length — 3 chars)
- [ ] `F.decrypt('abcd', key)` falls through to the existing `try/catch` (even-length, crypto error handled there)
- [ ] `F.decrypt(null, key)` / `F.decrypt('', key)` unaffected (`value && …` short-circuits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)